### PR TITLE
[WIP] Add advertisements protocol metrics

### DIFF
--- a/ethdebug.go
+++ b/ethdebug.go
@@ -13,9 +13,16 @@ type P2P struct {
 	OutboundTraffic Metric `json:"OutboundTraffic"`
 }
 
+type Whisper struct {
+	IngressAdv Metric `json:"IngressAdvertisement"`
+	EgressAdv  Metric `json:"EgressAdvertisement"`
+	FalseAdv   Metric `json:"FalseAdvertisement"`
+}
+
 // Metrics is a result of debug_metrics rpc call.
 type Metrics struct {
-	Peer2Peer P2P `json:"p2p"`
+	Peer2Peer P2P     `json:"p2p"`
+	Whisper   Whisper `json:"whisper"`
 }
 
 func getEthMetrics(url string) (rst Metrics, err error) { // nolint (deadcode)

--- a/scale_test.go
+++ b/scale_test.go
@@ -140,10 +140,10 @@ func runWithRetries(retries int, interval time.Duration, f func() error) error {
 // will be delivered to all peers. After that we will count how many new and old
 // envelopes received by each peer.
 func (s *WhisperScaleSuite) TestSymKeyMessaging() {
-	msgNum := 10
+	msgNum := 100
 	interval := 500 * time.Millisecond
-	senderCount := 5
-	payload := make([]byte, 512)
+	senderCount := 10
+	payload := make([]byte, 150)
 	if len(s.containers) < senderCount {
 		senderCount = len(s.containers)
 	}
@@ -225,6 +225,9 @@ func (s *WhisperScaleSuite) TestSymKeyMessaging() {
 		mu.Lock()
 		reports[i].Ingress = metrics.Peer2Peer.InboundTraffic.Overall
 		reports[i].Egress = metrics.Peer2Peer.OutboundTraffic.Overall
+		reports[i].IngressAdv = metrics.Whisper.IngressAdv.Overall
+		reports[i].EgressAdv = metrics.Whisper.EgressAdv.Overall
+		reports[i].FalseAdv = metrics.Whisper.FalseAdv.Overall
 		mu.Unlock()
 		return nil
 	}))

--- a/summary.go
+++ b/summary.go
@@ -44,6 +44,9 @@ type Report struct {
 	OldEnvelopes float64
 	Ingress      float64
 	Egress       float64
+	IngressAdv   float64
+	EgressAdv    float64
+	FalseAdv     float64
 }
 
 // Summary is a slice of stats collected from each node.
@@ -66,13 +69,16 @@ func (s Summary) Print(w io.Writer) error {
 		newEnv    float64
 		oldEnv    float64
 		oldPerNew = s.MeanOldPerNew()
+		iadv      float64
+		eadv      float64
+		fadv      float64
 	)
 	tab := newASCIITable(w)
 	_, err := fmt.Fprintln(w, "=== SUMMARY")
 	if err != nil {
 		return err
 	}
-	if err := tab.AddHeaders("HEADERS", "ingress", "egress", "dups", "new", "dups/new"); err != nil {
+	if err := tab.AddHeaders("HEADERS", "ingress", "egress", "dups", "new", "dups/new", "iadv", "eadv", "fadv"); err != nil {
 		return err
 	}
 	for i, r := range s {
@@ -80,6 +86,9 @@ func (s Summary) Print(w io.Writer) error {
 		egress += r.Egress
 		newEnv += r.NewEnvelopes
 		oldEnv += r.OldEnvelopes
+		iadv += r.IngressAdv
+		eadv += r.EgressAdv
+		fadv += r.FalseAdv
 		if err := tab.AddRow(
 			fmt.Sprintf("%d", i),
 			fmt.Sprintf("%f mb", r.Ingress/1024/1024),
@@ -87,6 +96,9 @@ func (s Summary) Print(w io.Writer) error {
 			fmt.Sprintf("%d", int64(r.OldEnvelopes)),
 			fmt.Sprintf("%d", int64(r.NewEnvelopes)),
 			fmt.Sprintf("%f", r.OldEnvelopes/r.NewEnvelopes),
+			fmt.Sprintf("%f mb", r.IngressAdv/1024/1024),
+			fmt.Sprintf("%f mb", r.EgressAdv/1024/1024),
+			fmt.Sprintf("%d", int64(r.FalseAdv)),
 		); err != nil {
 			return err
 		}
@@ -100,6 +112,9 @@ func (s Summary) Print(w io.Writer) error {
 		fmt.Sprintf("%d", int64(oldEnv)),
 		fmt.Sprintf("%d", int64(newEnv)),
 		fmt.Sprintf("%f", oldPerNew),
+		fmt.Sprintf("%f mb", iadv/1024/1024),
+		fmt.Sprintf("%f mb", eadv/1024/1024),
+		fmt.Sprintf("%d", int64(fadv)),
 	); err != nil {
 		return err
 	}


### PR DESCRIPTION
summary example: ingress advertisements traffic, egress, and number of envelopes received after an advertisement

|HEADERS	|ingress	|egress		|dups	|new	|dups/new	|iadv		|eadv		|fadv|
|-		|-		|-		|-	|-	|-		|-		|-		|-|
|0		|0.697331 mb	|0.492848 mb	|813	|900	|0.903333	|0.065188 mb	|0.050884 mb	|36|
|1		|0.621537 mb	|0.578712 mb	|649	|900	|0.721111	|0.054180 mb	|0.053998 mb	|39|
|2		|0.543715 mb	|0.623488 mb	|426	|900	|0.473333	|0.054378 mb	|0.058269 mb	|19|
|3		|0.569105 mb	|0.613193 mb	|476	|900	|0.528889	|0.057126 mb	|0.059158 mb	|31|
|4		|0.682023 mb	|0.509409 mb	|760	|900	|0.844444	|0.068553 mb	|0.052930 mb	|74|
|5		|0.607901 mb	|0.567313 mb	|589	|900	|0.654444	|0.058661 mb	|0.057470 mb	|19|
|6		|0.496064 mb	|0.690157 mb	|315	|900	|0.350000	|0.046523 mb	|0.059272 mb	|5|
|7		|0.627358 mb	|0.546008 mb	|636	|900	|0.706667	|0.062125 mb	|0.058816 mb	|46|
|8		|0.530846 mb	|0.639610 mb	|399	|900	|0.443333	|0.049786 mb	|0.058340 mb	|24|
|9		|0.538910 mb	|0.659469 mb	|403	|900	|0.447778	|0.052734 mb	|0.060118 mb	|35|
|TOTAL		|5.914790 mb	|5.920207 mb	|5466	|9000	|0.607333	|0.569255 mb	|0.569255 mb	|328|