### PR TITLE
Add dep and docker pull to dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,22 @@ Regular status-go image needs to be wrapped with a layer that has comcast (with 
 This is what Dockerfile for in this repository.
 
 ```bash
-docker build . -t statusteam/statusd-debug:latest
+$ docker build -f Dockerfile . -t statusteam/statusd-debug:latest
+$ docker build -f Dockerfile-boot . -t statusteam/bootnode-debug:latest
 ```
 
 Also we are using bootnode image in tests, but it is not wrapped at this point.
 
+Install go dependencies:
+```bash
+$ go get -u github.com/golang/dep/cmd/dep
+$ dep ensure
+```
+
 When you have docker installed and add comcast layer to status-go image you can run tests:
 
-```
-go test ./tests/ -v
+```bash
+$ go test ./tests/ -v
 ```
 
 There are no mandatory options in config, but you can explore them in `tests/config.go`.


### PR DESCRIPTION
Found some issues when trying to install and run tests as described on the readme:
```
$ go test ./tests/ -v
tests/config.go:8:2: cannot find package "docker.io/go-docker" in any of:
	/usr/local/Cellar/go/1.10/libexec/src/docker.io/go-docker (from $GOROOT)
	/Users/kumulo/go/src/docker.io/go-docker (from $GOPATH)
dockershim/shim.go:11:2: cannot find package "docker.io/go-docker/api/types" in any of:
	/usr/local/Cellar/go/1.10/libexec/src/docker.io/go-docker/api/types (from $GOROOT)
	/Users/kumulo/go/src/docker.io/go-docker/api/types (from $GOPATH)
dockershim/shim.go:12:2: cannot find package "docker.io/go-docker/api/types/container" in any of:
	/usr/local/Cellar/go/1.10/libexec/src/docker.io/go-docker/api/types/container (from $GOROOT)
	/Users/kumulo/go/src/docker.io/go-docker/api/types/container (from $GOPATH)
dockershim/shim.go:13:2: cannot find package "docker.io/go-docker/api/types/network" in any of:
	/usr/local/Cellar/go/1.10/libexec/src/docker.io/go-docker/api/types/network (from $GOROOT)
	/Users/kumulo/go/src/docker.io/go-docker/api/types/network (from $GOPATH)
cluster/interface.go:6:2: cannot find package "github.com/docker/go-connections/nat" in any of:
	/usr/local/Cellar/go/1.10/libexec/src/github.com/docker/go-connections/nat (from $GOROOT)
	/Users/kumulo/go/src/github.com/docker/go-connections/nat (from $GOPATH)
```

```
$ go test ./tests/ -v
... 
error creating bootnode tests_boot_0 10.0.170.2: Error: No such image: statusteam/bootnode-debug:latest
... 
```

I'm stil lgetting:
```
	            	Error response from daemon: cannot create network c89ca375b7f8938def7cffa2e20bb32cf9a4916dc6b02761a469b534cabb4fe2 (br-c89ca375b7f8): conflicts with network d2f6388ed2c40c0abf6b1813a453140ef5f8923d912280bfa42a1a66f4ef68a4 (br-d2f6388ed2c4): networks have overlapping IPv4
```
but doesn't seem related with installation itself.