### PR TITLE
Test for metering discovery

### DIFF
--- a/cluster/bootnode.go
+++ b/cluster/bootnode.go
@@ -99,3 +99,8 @@ func (b Bootnode) DisableConditions(ctx context.Context, opts ...network.Options
 		return b.backend.Execute(ctx, b.name, cmd)
 	}, ctx, opts...)
 }
+
+func (b Bootnode) Reboot(ctx context.Context) error {
+	log.Debug("reboot", "bootnode", b.name)
+	return b.backend.Reboot(ctx, b.name)
+}

--- a/cluster/interface.go
+++ b/cluster/interface.go
@@ -14,4 +14,5 @@ type Backend interface {
 	EnsureNetwork(context.Context, dockershim.NetOpts) (string, error)
 	RemoveNetwork(context.Context, string) error
 	ConnectionInfo(context.Context, string, int) ([]nat.PortBinding, error)
+	Reboot(context.Context, string) error
 }

--- a/cluster/peer.go
+++ b/cluster/peer.go
@@ -192,3 +192,15 @@ func (p Peer) healthcheck(ctx context.Context, retries int, interval time.Durati
 	}
 	return fmt.Errorf("peer %s failed healthcheck", p.name)
 }
+
+func (p *Peer) Reboot(ctx context.Context) (err error) {
+	log.Debug("reboot", "peer", p.name)
+	if err = p.backend.Reboot(ctx, p.name); err != nil {
+		return err
+	}
+	p.client, err = p.makeRPCClient(ctx)
+	if err != nil {
+		return err
+	}
+	return p.healthcheck(ctx, 20, time.Second)
+}

--- a/dockershim/shim.go
+++ b/dockershim/shim.go
@@ -113,6 +113,11 @@ func (p DockerShim) Create(ctx context.Context, id string, opts CreateOpts) erro
 	return p.client.ContainerStart(ctx, id, types.ContainerStartOptions{})
 }
 
+func (p DockerShim) Reboot(ctx context.Context, id string) error {
+	timeout := 5 * time.Second
+	return p.client.ContainerRestart(ctx, id, &timeout)
+}
+
 func (p DockerShim) EnsureNetwork(ctx context.Context, opts NetOpts) (string, error) {
 	// check that cidr intersects
 	net, err := p.client.NetworkInspect(ctx, opts.NetID, types.NetworkInspectOptions{})

--- a/metrics/ascii.go
+++ b/metrics/ascii.go
@@ -15,6 +15,7 @@ func ToASCII(tab *Table, writer io.Writer) *tablewriter.Table {
 	atab := tablewriter.NewWriter(writer)
 	// markdown format
 	atab.SetBorders(tablewriter.Border{Left: true, Top: false, Right: true, Bottom: false})
+	atab.SetCenterSeparator("|")
 	headers := []string{}
 	for _, c := range tab.columns {
 		headers = append(headers, c.(Stringer).String())

--- a/metrics/collections.go
+++ b/metrics/collections.go
@@ -17,3 +17,9 @@ func DiscoveryColumns() []interface{} {
 		RawColumn{[]string{"discv5", "OutboundTraffic", "Overall"}, "discovery/outbound"},
 	}
 }
+
+func OnlyPeers() []interface{} {
+	return []interface{}{
+		RawColumn{[]string{"p2p", "Peers", "Overall"}, "p2p/peers"},
+	}
+}

--- a/tests/metrics_test.go
+++ b/tests/metrics_test.go
@@ -6,17 +6,36 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/status-im/status-scale/cluster"
 	"github.com/status-im/status-scale/metrics"
 	"github.com/stretchr/testify/require"
 )
 
-func TestMetrics(t *testing.T) {
+func TestMeterDiscovery(t *testing.T) {
 	c := ClusterFromConfig()
-	require.NoError(t, c.Create(context.TODO(), cluster.ScaleOpts{Boot: 1, Relay: 2, Deploy: true}))
+	require.NoError(t, c.Create(context.TODO(), cluster.ScaleOpts{Boot: 2, Relay: 20, Deploy: true}))
 	defer c.Clean(context.TODO())
-	tab := metrics.NewCompleteTab("container", metrics.P2PColumns(), metrics.DiscoveryColumns())
-	time.Sleep(30 * time.Second) // some time for metrics to accumulate
-	require.NoError(t, c.FillMetrics(context.TODO(), tab))
+	for i := 0; i < 10; i++ {
+		require.NoError(t, c.Create(context.TODO(), cluster.ScaleOpts{Users: 1, Deploy: true}))
+		time.Sleep(2 * time.Second)
+	}
+	time.Sleep(10 * time.Second) // some time for metrics to accumulate
+	tab := metrics.NewCompleteTab("container", metrics.DiscoveryColumns(), metrics.OnlyPeers())
+	require.NoError(t, c.FillMetrics(context.TODO(), tab, cluster.MetricsOpts{NoRelay: true}))
+	metrics.ToASCII(tab, os.Stdout).Render()
+
+	// FIXME think about extending metrics table with summary rows
+	log.Info("see that metrics didn't change. discovery was stopped")
+	time.Sleep(5 * time.Second)
+	tab = metrics.NewCompleteTab("container", metrics.DiscoveryColumns(), metrics.OnlyPeers())
+	require.NoError(t, c.FillMetrics(context.TODO(), tab, cluster.MetricsOpts{NoRelay: true}))
+	metrics.ToASCII(tab, os.Stdout).Render()
+
+	log.Info("reboot nodes. no singnificant traffic should be observed.")
+	require.NoError(t, c.Reboot(context.TODO(), cluster.User))
+	time.Sleep(5 * time.Second)
+	tab = metrics.NewCompleteTab("container", metrics.DiscoveryColumns(), metrics.OnlyPeers())
+	require.NoError(t, c.FillMetrics(context.TODO(), tab, cluster.MetricsOpts{NoRelay: true}))
 	metrics.ToASCII(tab, os.Stdout).Render()
 }


### PR DESCRIPTION
Closes: https://github.com/status-im/status-scale/issues/13

=== RUN   TestMeterDiscovery

| CONTAINER  | DISCOVERY/INBOUND | DISCOVERY/OUTBOUND | P2P/PEERS |
|------------|-------------------|--------------------|-----------|
| ddd_user_0 |             48115 |             107473 |         2 |
| ddd_user_1 |             37729 |              36375 |         2 |
| ddd_user_2 |             34416 |              24610 |         2 |
| ddd_user_3 |             35315 |              20638 |         2 |
| ddd_user_4 |             33408 |              15070 |         2 |
| ddd_user_5 |             34663 |              18012 |         2 |
| ddd_user_6 |             34727 |              36595 |         2 |
| ddd_user_7 |             34326 |              18443 |         2 |
| ddd_user_8 |             35155 |              16402 |         2 |
| ddd_user_9 |             40900 |              43097 |         2 |

INFO [06-15|14:54:26] see that metrics didn't change. discovery was stopped 

| CONTAINER  | DISCOVERY/INBOUND | DISCOVERY/OUTBOUND | P2P/PEERS |
|------------|-------------------|--------------------|-----------|
| ddd_user_0 |             48115 |             107473 |         2 |
| ddd_user_1 |             37729 |              36375 |         2 |
| ddd_user_2 |             34416 |              24610 |         2 |
| ddd_user_3 |             35315 |              20638 |         2 |
| ddd_user_4 |             33408 |              15070 |         2 |
| ddd_user_5 |             34663 |              18012 |         2 |
| ddd_user_6 |             34727 |              36595 |         2 |
| ddd_user_7 |             34326 |              18443 |         2 |
| ddd_user_8 |             35155 |              16402 |         2 |
| ddd_user_9 |             40900 |              43097 |         2 |

INFO [06-15|14:54:31] reboot nodes. no singnificant traffic should be observed. 

| CONTAINER  | DISCOVERY/INBOUND | DISCOVERY/OUTBOUND | P2P/PEERS |
|------------|-------------------|--------------------|-----------|
| ddd_user_0 |               348 |                264 |         2 |
| ddd_user_1 |               348 |                264 |         2 |
| ddd_user_2 |              4195 |               2759 |         2 |
| ddd_user_3 |              1789 |                746 |         2 |
| ddd_user_4 |               348 |                264 |         2 |
| ddd_user_5 |              1932 |                571 |         2 |
| ddd_user_6 |               348 |                264 |         2 |
| ddd_user_7 |               729 |                264 |         2 |
| ddd_user_8 |               729 |                264 |         2 |
| ddd_user_9 |              1052 |                264 |         2 |
